### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ resolvers += Resolver.bintrayIvyRepo("zamblauskas", "sbt-plugins")
 addSbtPlugin("zamblauskas" % "sbt-examplestest" % "<latest_version>")
 ```
 
-| version  | SBT  |
-|----------|------|
-| 0.1.1    | 0.13 |
-| 0.1.2+   | 1.x  |
+| version  | SBT  | scalatest |
+|----------|------|-----------|
+| 0.1.1    | 0.13 | 3.0.4     |
+| 0.1.2    | 1.x  | 3.0.4     |
+| 0.2.0+   | 1.x  | 3.1.0     |
 
-Plugin will be enabled by default.  
-It will find all `.md` files in the base directory, generate unit test code for every Scala block (marked as \`\`\` scala) and put it in `target/scala-<version>/src_managed/test`.  
+Plugin will be enabled by default.
+It will find all `.md` files in the base directory, generate unit test code for every Scala block (marked as \`\`\` scala) and put it in `target/scala-<version>/src_managed/test`.
 Tests will be run during `sbt test`.
 
 Dependencies
@@ -30,7 +31,7 @@ Dependencies
 
 Your project must have a `ScalaTest` library on path. E.g.:
 ```scala
-"org.scalatest" %% "scalatest" % "3.0.4" % Test
+"org.scalatest" %% "scalatest" % "3.1.0" % Test
 ```
 
 Example
@@ -38,9 +39,9 @@ Example
 
 If you have `README.md`:
 
-> \`\`\` scala  
-> val foo = "bar"  
-> foo shouldBe "bar"  
+> \`\`\` scala
+> val foo = "bar"
+> foo shouldBe "bar"
 > \`\`\`
 
 plugin will create `target/scala-2.11/src_managed/test/READMETest.scala`:

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ organization := "zamblauskas"
 
 name := "sbt-examplestest"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.10"
 
 libraryDependencies ++= Seq(
-  "com.vladsch.flexmark"  %  "flexmark"    % "0.28.32",
-  "com.google.guava"      %  "guava"       % "23.6-jre",
+  "com.vladsch.flexmark"  %  "flexmark"    % "0.28.38",
+  "com.google.guava"      %  "guava"       % "28.1-jre",
   "commons-io"            %  "commons-io"  % "2.6",
-  "org.scalatest"         %% "scalatest"                   % "3.0.4" % Test,
+  "org.scalatest"         %% "scalatest"                   % "3.1.0" % Test,
   "org.scalamock"         %% "scalamock-scalatest-support" % "3.6.0" % Test
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
-
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
+++ b/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
@@ -12,9 +12,10 @@ trait TestGenerator {
 object ScalaTestGenerator extends TestGenerator {
 
   def generate(baseName: String, examples: Seq[CodeExample]): String = {
-    s"""import org.scalatest.{FunSpec, Matchers}
+    s"""import org.scalatest.funsuite.AnyFunSuite
+       |import org.scalatest.matchers.should.Matchers
        |
-       |class ${baseName}Test extends FunSpec with Matchers {
+       |class ${baseName}Test extends AnyFunSuite with Matchers {
        |  describe("$baseName") {
        |${examples.zipWithIndex.map(generateExample).mkString("\n")}
        |  }

--- a/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
+++ b/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
@@ -12,10 +12,10 @@ trait TestGenerator {
 object ScalaTestGenerator extends TestGenerator {
 
   def generate(baseName: String, examples: Seq[CodeExample]): String = {
-    s"""import org.scalatest.funsuite.AnyFunSuite
+    s"""import org.scalatest.funspec.AnyFunSpec
        |import org.scalatest.matchers.should.Matchers
        |
-       |class ${baseName}Test extends AnyFunSuite with Matchers {
+       |class ${baseName}Test extends AnyFunSpec with Matchers {
        |  describe("$baseName") {
        |${examples.zipWithIndex.map(generateExample).mkString("\n")}
        |  }

--- a/src/test/scala/zamblauskas/examplestest/FlexMarkCodeExampleExtractor$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/FlexMarkCodeExampleExtractor$Test.scala
@@ -1,9 +1,10 @@
 package zamblauskas.examplestest
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import zamblauskas.examplestest.Util._
 
-class FlexMarkCodeExampleExtractor$Test extends FunSuite with Matchers {
+class FlexMarkCodeExampleExtractor$Test extends AnyFunSuite with Matchers {
 
   test("extract all code blocks") {
     val examples = FlexMarkCodeExampleExtractor.extract(readResource("README.md"))

--- a/src/test/scala/zamblauskas/examplestest/ScalaTestGenerator$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/ScalaTestGenerator$Test.scala
@@ -1,8 +1,9 @@
 package zamblauskas.examplestest
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ScalaTestGenerator$Test extends FunSuite with Matchers {
+class ScalaTestGenerator$Test extends AnyFunSuite with Matchers {
 
   test("generate test code") {
     val examples = Seq(
@@ -12,9 +13,10 @@ class ScalaTestGenerator$Test extends FunSuite with Matchers {
 
     val generated = ScalaTestGenerator.generate("GeneratorTest", examples)
 
-    generated shouldBe """import org.scalatest.{FunSpec, Matchers}
+    generated shouldBe """import org.scalatest.funsuite.AnyFunSuite
+                         |import org.scalatest.matchers.should.Matchers
                          |
-                         |class GeneratorTestTest extends FunSpec with Matchers {
+                         |class GeneratorTestTest extends AnyFunSuite with Matchers {
                          |  describe("GeneratorTest") {
                          |    it("code block #0") {
                          |code line 1

--- a/src/test/scala/zamblauskas/examplestest/ScalaTestGenerator$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/ScalaTestGenerator$Test.scala
@@ -13,10 +13,10 @@ class ScalaTestGenerator$Test extends AnyFunSuite with Matchers {
 
     val generated = ScalaTestGenerator.generate("GeneratorTest", examples)
 
-    generated shouldBe """import org.scalatest.funsuite.AnyFunSuite
+    generated shouldBe """import org.scalatest.funspec.AnyFunSpec
                          |import org.scalatest.matchers.should.Matchers
                          |
-                         |class GeneratorTestTest extends AnyFunSuite with Matchers {
+                         |class GeneratorTestTest extends AnyFunSpec with Matchers {
                          |  describe("GeneratorTest") {
                          |    it("code block #0") {
                          |code line 1

--- a/src/test/scala/zamblauskas/examplestest/TestWriter$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/TestWriter$Test.scala
@@ -1,10 +1,11 @@
 package zamblauskas.examplestest
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import zamblauskas.examplestest.Util._
 
-class TestWriter$Test extends FunSuite with Matchers with Tmp with MockFactory {
+class TestWriter$Test extends AnyFunSuite with Matchers with Tmp with MockFactory {
 
   test("generate tests for given code block types") { withTempDir2 { (inputDir, outputDir) =>
     val extractor = mock[CodeExampleExtractor]


### PR DESCRIPTION
Most importantly update scalatest to 3.1.0. This also required updating scalatest class names and paths:

`org.scalatest.FunSuite` --> `org.scalatest.funspec.AnyFunSpec`
`org.scalatest.Matchers` --> `org.scalatest.matchers.should.Matchers`

With this change I will be able to use this in one of my projects (https://github.com/2m/ciris-hocon) where I would like to update to the latest scalatest version.

This change will make `sbt-examplestest` incompatible with older scalatest versions. So after merging it should be released as `v0.2.0`.