### PR TITLE
Add MUnit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,16 @@ Check for the latest version and add to your `project/plugins.sbt`:
 addSbtPlugin("io.github.zamblauskas" % "sbt-examplestest" % "<latest_version>")
 ```
 
-| version  | SBT  | scalatest |
-|----------|------|-----------|
-| 0.1.1    | 0.13 | 3.0.4     |
-| 0.1.2    | 1.x  | 3.0.4     |
-| 0.2.0+   | 1.x  | 3.1.0     |
+| version  | SBT  | scalatest | munit-cats-effect-3 |
+|----------|------|-----------|---------------------|
+| 0.1.1    | 0.13 | 3.0.4     |                     |
+| 0.1.2    | 1.x  | 3.0.4     |                     |
+| 0.2.0+   | 1.x  | 3.1.0     | 1.0.3               |
 
 Plugin will be enabled by default.
-It will find all `.md` files in the base directory, generate unit test code for every Scala block (marked as \`\`\` scala) and put it in `target/scala-<version>/src_managed/test`.
+It will detect the testing library used in the project and select corresponding code generator.
+Then it will find all `.md` files in the base directory, generate unit test code for every Scala block (marked as \`\`\` scala) and put it in `target/scala-<version>/src_managed/test`.
 Tests will be run during `sbt test`.
-
-Dependencies
-==============================
-
-Your project must have a `ScalaTest` library on path. E.g.:
-```scala
-"org.scalatest" %% "scalatest" % "3.1.0" % Test
-```
 
 Example
 ==============================

--- a/src/main/scala/zamblauskas/examplestest/ExamplesTestPlugin.scala
+++ b/src/main/scala/zamblauskas/examplestest/ExamplesTestPlugin.scala
@@ -8,6 +8,7 @@ object ExamplesTestPlugin extends AutoPlugin {
 
   val examplesTestInputFiles = settingKey[Seq[File]]("Files containing code examples.")
   val examplesTestCodeBlockTypes = settingKey[Seq[String]]("Code block types to generate tests for.")
+  val examplesTestGenerator = taskKey[Option[TestGenerator]]("Testing library specific code generator.")
   val examplesTestGenTests = taskKey[Seq[File]]("Generates test files for code examples.")
 
   override def trigger: PluginTrigger = AllRequirements
@@ -15,17 +16,33 @@ object ExamplesTestPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     examplesTestInputFiles := (baseDirectory.value * "*.md").filter(_.isFile).get,
     examplesTestCodeBlockTypes := Seq("scala"),
+    examplesTestGenerator := generatorFromDependencies(allDependencies.value),
     examplesTestGenTests := {
-      (managedSourceDirectories in Test).value.headOption match {
-        case None =>
+      ((Test / managedSourceDirectories).value.headOption, examplesTestGenerator.value) match {
+        case (None, _) =>
           streams.value.log.error("Cannot find managed sources directory.")
           Seq.empty
-        case Some(dir) =>
-          val writer = new TestWriter(dir, examplesTestCodeBlockTypes.value, FlexMarkCodeExampleExtractor, ScalaTestGenerator)
+        case (_, None) =>
+          streams.value.log.error("Cannot determine testing library.")
+          Seq.empty
+        case (Some(dir), Some(generator)) =>
+          val writer = new TestWriter(dir, examplesTestCodeBlockTypes.value, FlexMarkCodeExampleExtractor, generator)
           examplesTestInputFiles.value.flatMap(writer.write)
       }
     },
-    sourceGenerators in Test += examplesTestGenTests.taskValue,
+    Test / sourceGenerators += examplesTestGenTests.taskValue,
     watchSources ++= examplesTestInputFiles.value
   )
+
+  private val moduleToGenerator = Map(
+    "munit-cats-effect-3" -> MunitCatsEffect3Generator,
+    "scalatest" -> ScalaTestGenerator
+  )
+
+  def generatorFromDependencies(dependencies: Seq[ModuleID]): Option[TestGenerator] = {
+    val modules = dependencies.filter(_.configurations.exists(_ == "test")).map(_.name)
+    moduleToGenerator.collectFirst {
+      case (module, generator) if modules.contains(module) => generator
+    }
+  }
 }

--- a/src/main/scala/zamblauskas/examplestest/MunitCatsEffect3Generator.scala
+++ b/src/main/scala/zamblauskas/examplestest/MunitCatsEffect3Generator.scala
@@ -1,0 +1,18 @@
+package zamblauskas.examplestest
+
+object MunitCatsEffect3Generator extends TestGenerator {
+
+  def generate(baseName: String, examples: Seq[CodeExample]): String = {
+    s"""import munit.CatsEffectSuite
+       |
+       |class ${baseName}Suite extends CatsEffectSuite {
+       |${examples.zipWithIndex.map(generateExample).mkString("\n")}
+       |}""".stripMargin
+  }
+
+  private def generateExample: ((CodeExample, Int)) => String = { case (example, idx) =>
+     s"""  test("code block #$idx") {
+       |${example.block}  }""".stripMargin
+  }
+
+}

--- a/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
+++ b/src/main/scala/zamblauskas/examplestest/ScalaTestGenerator.scala
@@ -1,14 +1,5 @@
 package zamblauskas.examplestest
 
-trait TestGenerator {
-  /**
-   * @param baseName name of the input file without the extension,
-   *                 should be used in test name to specify where the code example came from
-   * @return generated test code
-   */
-  def generate(baseName: String, examples: Seq[CodeExample]): String
-}
-
 object ScalaTestGenerator extends TestGenerator {
 
   def generate(baseName: String, examples: Seq[CodeExample]): String = {

--- a/src/main/scala/zamblauskas/examplestest/TestGenerator.scala
+++ b/src/main/scala/zamblauskas/examplestest/TestGenerator.scala
@@ -1,0 +1,10 @@
+package zamblauskas.examplestest
+
+trait TestGenerator {
+  /**
+   * @param baseName name of the input file without the extension,
+   *                 should be used in test name to specify where the code example came from
+   * @return generated test code
+   */
+  def generate(baseName: String, examples: Seq[CodeExample]): String
+}

--- a/src/test/scala/zamblauskas/examplestest/ExamplesTestPlugin$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/ExamplesTestPlugin$Test.scala
@@ -1,0 +1,17 @@
+package zamblauskas.examplestest
+
+import sbt._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ExamplesTestPlugin$Test extends AnyFunSuite with Matchers {
+  test("munit cats effect 3 generator") {
+    val dependencies = Seq("org.typelevel" %% "munit-cats-effect-3" % "1.0.3" % "test")
+    ExamplesTestPlugin.generatorFromDependencies(dependencies) shouldBe Some(MunitCatsEffect3Generator)
+  }
+
+  test("scalatest generator") {
+    val dependencies = Seq("org.scalatest" %% "scalatest" % "3.1.0" % Test)
+    ExamplesTestPlugin.generatorFromDependencies(dependencies) shouldBe Some(ScalaTestGenerator)
+  }
+}

--- a/src/test/scala/zamblauskas/examplestest/MunitCatsEffect3Generator$Test.scala
+++ b/src/test/scala/zamblauskas/examplestest/MunitCatsEffect3Generator$Test.scala
@@ -1,0 +1,28 @@
+package zamblauskas.examplestest
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MunitCatsEffect3Generator$Test extends AnyFunSuite with Matchers {
+
+  test("generate test code") {
+    val examples = Seq(
+      CodeExample("type 1", "code line 1\n"),
+      CodeExample("type 2", "code line 1\ncode line 2\n")
+    )
+
+    val generated = MunitCatsEffect3Generator.generate("GeneratorTest", examples)
+
+    generated shouldBe """import munit.CatsEffectSuite
+                         |
+                         |class GeneratorTestSuite extends CatsEffectSuite {
+                         |  test("code block #0") {
+                         |code line 1
+                         |  }
+                         |  test("code block #1") {
+                         |code line 1
+                         |code line 2
+                         |  }
+                         |}""".stripMargin
+  }
+}


### PR DESCRIPTION
Adds munit support when used with munit-cats-effect-3 integration library.

Code generator is automatically selected after inspecting project dependencies.